### PR TITLE
docs: Add a note on when to add reviewers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,5 @@ Thanks for creating this pull request 🤗
 
 - [ ] I have tested my work
 - [ ] I need you to test it too
+
+<!-- IMPORTANT: Add reviewers ONLY WHEN the PR is ready for review (i.e. not a Draft) -->


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗
-->

## 📑 What

Adds a note on when to add reviewers.

## ❓ Why

1. Why this PR: Because assigning reviewers to a draft PR can be confusing: some will completely miss the "Draft" status and add their review prematurly;
2. But why submit a PR: Because the main branch is protected.

## ⚡ How to Review

Just read the change and give it a thumbs up or down. You know the drill.

## ✅ Testing

N/A